### PR TITLE
Paper over differences between GNU/BSD sed / cat

### DIFF
--- a/tests/basic.mustache
+++ b/tests/basic.mustache
@@ -7,3 +7,4 @@ nothing to see here
 foo {{BAR}} baz
 {{/FOO}}
 {{#FOO}}{{#BAR}}{{^BAZ}}nested{nested{{/BAZ}}{{/BAR}}{{/FOO}}
+\backslash

--- a/tests/basic.mustache.out
+++ b/tests/basic.mustache.out
@@ -5,3 +5,4 @@ foo bar baz
 foo bar baz
 
 nested{nested
+\backslash


### PR DESCRIPTION
Mostly a convenience so that mustache.sh works on OSX.

Also a regression test for preserving backslashes, since it wasn't immediately obvious to me what the second `sed` pattern was doing in the mustache output I was testing.

PS, thanks for writing this :+1: 
