### PR TITLE
Handle strict unbound checking (set -u)

### DIFF
--- a/lib/mustache.sh
+++ b/lib/mustache.sh
@@ -1,6 +1,11 @@
 # `mustache.sh`, Mustache in POSIX shell.
 
+# Exit immediately if there is an error.
 set -e
+
+# Initialize variables if unset
+: ${MUSTACHE_DEBUG:=""}
+: ${_M_PREV_C:=""}
 
 # File descriptor 3 is commandeered for debug output, which may end up being
 # forwarded to standard error.


### PR DESCRIPTION
I was running mustache in a script with `set -u` enabled, leading mustache to throw errors about unbound variables. By setting default values for two variables, it can handle this case.

This is difficult to add a test for.

I believe the [default assignment parameter expansion](http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_06_02) is POSIX compliant, but could be missing some nuance.
